### PR TITLE
refactor: nextId useRef 변경 + 삭제 로직 통합

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,13 +6,12 @@ interface StackItem {
   text: string;
 }
 
-let nextId = 1;
-
 export default function App() {
   const [items, setItems] = useState<StackItem[]>([]);
   const [input, setInput] = useState("");
   const [pinned, setPinned] = useState(true);
   const inputRef = useRef<HTMLInputElement>(null);
+  const nextIdRef = useRef(1);
 
   // 앱 시작 시 입력창에 포커스 + always-on-top 초기 설정
   useEffect(() => {
@@ -35,10 +34,14 @@ export default function App() {
       handleCommand(value);
     } else {
       // 새 아이템을 맨 위에 추가
-      setItems((prev) => [{ id: nextId++, text: value }, ...prev]);
+      setItems((prev) => [{ id: nextIdRef.current++, text: value }, ...prev]);
     }
 
     setInput("");
+  };
+
+  const deleteItem = (index: number) => {
+    setItems((prev) => prev.filter((_, i) => i !== index));
   };
 
   const handleCommand = (cmd: string) => {
@@ -49,19 +52,15 @@ export default function App() {
       const num = parseInt(parts[1], 10);
       if (!isNaN(num) && num >= 1) {
         // 번호는 1부터 시작, 배열 인덱스는 0부터
-        setItems((prev) => prev.filter((_, i) => i + 1 !== num));
+        deleteItem(num - 1);
       }
     } else if (command === "/pop") {
       // 맨 위(첫 번째) 아이템 삭제
-      setItems((prev) => prev.slice(1));
+      deleteItem(0);
     } else if (command === "/clear") {
       // 모든 아이템 삭제
       setItems([]);
     }
-  };
-
-  const deleteItem = (index: number) => {
-    setItems((prev) => prev.filter((_, i) => i !== index));
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {


### PR DESCRIPTION
## Summary
- `nextId` 모듈 레벨 전역 변수를 컴포넌트 내부 `useRef`로 이동하여 React 생명주기 안에서 관리 (#7)
- `/del`, `/pop` 명령어가 `deleteItem` 함수를 재사용하도록 중복 삭제 로직 통합 (#8 

## Test plan
- [x] 아이템 추가 후 X 버튼으로 삭제 동작 확인
- [x] `/del {번호}` 명령어로 특정 아이템 삭제 확인
- [x] `/pop` 명령어로 맨 위 아이템 삭제 확인
- [x] `/clear` 명령어로 전체 삭제 확인
- [x] `npx tsc --noEmit` 타입 체크 통과
- [x] `npm run lint` 린트 통과

Closes #7, Closes #8 

🤖 Generated with [Claude Code](https://claude.com/claude-code)