### PR TITLE
feat: 데이터 영속성 추가 (앱 재시작 시 데이터 유지)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
+        "@tauri-apps/plugin-store": "^2.4.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
       },
@@ -1378,6 +1379,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-store": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-store/-/plugin-store-2.4.2.tgz",
+      "integrity": "sha512-0ClHS50Oq9HEvLPhNzTNFxbWVOqoAp3dRvtewQBeqfIQ0z5m3JRnOISIn2ZVPCrQC0MyGyhTS9DWhHjpigQE7A==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "type": "commonjs",
   "dependencies": {
     "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/plugin-store": "^2.4.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,3 +21,4 @@ tauri-build = { version = "2.5.4", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "2.10.0", features = [] }
+tauri-plugin-store = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
   ],
   "permissions": [
     "core:default",
-    "core:window:allow-set-always-on-top"
+    "core:window:allow-set-always-on-top",
+    "store:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ use tauri::Manager;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
+    .plugin(tauri_plugin_store::Builder::new().build())
     .setup(|app| {
       let window = app.get_webview_window("main").unwrap();
       window.set_always_on_top(true)?;


### PR DESCRIPTION
## Summary
- `tauri-plugin-store` v2를 사용하여 앱 데이터 디렉터리에 JSON 파일(`store.json`)로 메모 데이터를 자동 저장/로드
- 앱 종료 후 재시작해도 기존 메모가 유지됨
- `isLoadedRef`로 초기 로드 완료 전 빈 상태가 저장되는 것을 방지
- 에러 발생 시 `console.error` 로깅 후 인메모리 모드로 graceful 폴백

## Changes
- `src-tauri/Cargo.toml` — `tauri-plugin-store = "2"` 의존성 추가
- `src-tauri/src/lib.rs` — store 플러그인 등록
- `src-tauri/capabilities/default.json` — `store:default` 권한 추가
- `package.json` — `@tauri-apps/plugin-store` npm 패키지 설치
- `src/App.tsx` — `LazyStore` 기반 데이터 로드/저장 로직 추가

## Test plan
- [x] `npm run tauri dev`로 실행
- [x] 아이템 추가/삭제 후 앱 종료 → 재시작 시 데이터 유지 확인
- [x] `/clear` 실행 후 재시작 시 빈 상태 유지 확인
- [x] `npx tsc --noEmit` 타입 체크 통과 확인

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)