### PR TITLE
feat: 아이템 인라인 수정 기능 추가

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -139,6 +139,30 @@ body {
   word-break: break-word;
 }
 
+/* 편집 모드 */
+.stack-item.editing {
+  border: 1px solid var(--accent);
+  background: rgba(124, 92, 252, 0.08);
+}
+
+.edit-input {
+  flex: 1;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+  font-family: inherit;
+  outline: none;
+  user-select: text;
+  transition: border-color 0.15s;
+}
+
+.edit-input:focus {
+  border-color: var(--accent);
+}
+
 .stack-item .delete-btn {
   background: none;
   border: none;


### PR DESCRIPTION
## Summary
- 더블클릭 또는 `/edit 번호` 슬래시 명령어로 아이템 인라인 편집 기능 추가
- Enter로 저장, Escape로 취소, onBlur 자동 저장 지원
- 한국어 IME 조합 중 Enter 오작동 방지 (isComposing 체크)

## 변경 내역
- `src/App.tsx`: editingId 상태, startEditing/saveEdit/cancelEdit/handleEditKeyDown 함수, JSX 인라인 편집 UI
- `src/styles.css`: .stack-item.editing, .edit-input 스타일 추가

## Test plan
- [ ] 아이템 더블클릭 → 인라인 편집 → Enter 저장 확인
- [ ] Escape 취소 → 원본 텍스트 유지 확인
- [ ] `/edit 3` 입력 → 3번 아이템 편집 모드 전환 확인
- [ ] 한국어 입력 후 Enter 조합 완료 동작 확인
- [ ] 빈 텍스트로 저장 시 원본 유지 확인
- [ ] 편집 중 다른 아이템 더블클릭 → 기존 저장 후 새 편집
- [ ] 앱 재시작 후 수정 내용 유지 확인 (자동 저장)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)