### PR TITLE
feat: 드래그 앤 드롭으로 아이템 순서 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-store": "^2.4.2",
         "react": "^19.2.4",
@@ -303,6 +306,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1925,6 +1981,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-store": "^2.4.2",
     "react": "^19.2.4",

--- a/src/styles.css
+++ b/src/styles.css
@@ -124,6 +124,24 @@ body {
   }
 }
 
+/* 드래그 핸들 */
+.drag-handle {
+  cursor: grab;
+  color: var(--text-muted);
+  font-size: 14px;
+  padding: 2px 4px;
+  flex-shrink: 0;
+  opacity: 0.4;
+  transition: opacity 0.15s;
+  user-select: none;
+  touch-action: none;
+}
+.drag-handle:hover { opacity: 0.8; }
+.drag-handle:active { cursor: grabbing; }
+
+/* 정렬 중 slideIn 애니메이션 비활성화 */
+.stack-item.sorting { animation: none; }
+
 .stack-item .number {
   color: var(--text-muted);
   font-size: 12px;


### PR DESCRIPTION
## Summary
- `@dnd-kit` 라이브러리를 사용하여 드래그 앤 드롭 기반 아이템 재정렬 기능 추가
- 드래그 핸들(⠿)을 잡고 아이템을 위/아래로 이동하여 순서 변경 가능
- 편집 중인 아이템은 드래그 비활성화, PointerSensor distance 5px로 클릭/더블클릭 충돌 방지

## 변경 내용
- `SortableItem` 컴포넌트 추출 및 `useSortable` 훅 적용
- `DndContext` + `SortableContext`로 아이템 리스트 래핑
- `PointerSensor`, `KeyboardSensor` 센서 설정
- 드래그 핸들 스타일 및 정렬 중 slideIn 애니메이션 비활성화

## Test plan
- [x] 드래그 핸들(⠿) 잡고 아이템 위/아래 이동 → 순서 변경 확인
- [x] 더블클릭 편집 정상 동작 (드래그와 충돌 없음)
- [x] 편집 중인 아이템은 드래그 비활성화
- [x] 새 아이템 추가 시 slideIn 애니메이션 정상 동작
- [x] `/del`, `/pop`, `/edit`, `/clear` 명령어가 재정렬 후에도 정상 동작
- [x] `npx tsc --noEmit` 타입 에러 없음

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)