### PR TITLE
refactor: CSP 설정 및 App.tsx 컴포넌트/훅 분리

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'"
     }
   },
   "bundle": {

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,9 @@
+export function EmptyState() {
+  return (
+    <div className="empty-state">
+      /del # · /edit # · /pop · /clear
+      <br />
+      Ctrl+Shift+T Focus · Ctrl+Shift+P Pin
+    </div>
+  );
+}

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -1,0 +1,40 @@
+interface InputBarProps {
+  input: string;
+  setInput: (value: string) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  pinned: boolean;
+  togglePin: () => void;
+  onFocus: () => void;
+}
+
+export function InputBar({
+  input,
+  setInput,
+  onKeyDown,
+  inputRef,
+  pinned,
+  togglePin,
+  onFocus,
+}: InputBarProps) {
+  return (
+    <div className="input-bar">
+      <input
+        ref={inputRef}
+        type="text"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={onKeyDown}
+        onFocus={onFocus}
+        placeholder="Type and press Enter..."
+      />
+      <button
+        className={`pin-btn ${pinned ? "active" : ""}`}
+        onClick={togglePin}
+        title={pinned ? "Unpin (Ctrl+Shift+P)" : "Pin to top (Ctrl+Shift+P)"}
+      >
+        📌
+      </button>
+    </div>
+  );
+}

--- a/src/components/StackItem.tsx
+++ b/src/components/StackItem.tsx
@@ -1,0 +1,77 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { StackItem as StackItemType } from "../types";
+
+interface StackItemProps {
+  item: StackItemType;
+  index: number;
+  editingId: number | null;
+  editInputRef: React.RefObject<HTMLInputElement | null>;
+  startEditing: (id: number) => void;
+  saveEdit: (id: number, newText: string) => void;
+  handleEditKeyDown: (
+    e: React.KeyboardEvent<HTMLInputElement>,
+    id: number
+  ) => void;
+  deleteItem: (index: number) => void;
+}
+
+export function SortableItem({
+  item,
+  index,
+  editingId,
+  editInputRef,
+  startEditing,
+  saveEdit,
+  handleEditKeyDown,
+  deleteItem,
+}: StackItemProps) {
+  const isEditing = editingId === item.id;
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id.toString(), disabled: isEditing });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : undefined,
+    zIndex: isDragging ? 1 : undefined,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`stack-item ${isEditing ? "editing" : ""} ${transform ? "sorting" : ""}`}
+      onDoubleClick={() => startEditing(item.id)}
+    >
+      <span className="drag-handle" {...attributes} {...listeners}>
+        ⠿
+      </span>
+      <span className="number">{index + 1}</span>
+      {isEditing ? (
+        <input
+          ref={editInputRef}
+          className="edit-input"
+          defaultValue={item.text}
+          onKeyDown={(e) => handleEditKeyDown(e, item.id)}
+          onBlur={(e) => saveEdit(item.id, e.currentTarget.value)}
+        />
+      ) : (
+        <span className="content">{item.text}</span>
+      )}
+      <button
+        className="delete-btn"
+        onClick={() => deleteItem(index)}
+        title="Delete"
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -1,0 +1,41 @@
+import type { StackItem } from "../types";
+
+interface UseCommandsParams {
+  items: StackItem[];
+  deleteItem: (index: number) => void;
+  startEditing: (id: number) => void;
+  setItems: React.Dispatch<React.SetStateAction<StackItem[]>>;
+}
+
+export function useCommands({
+  items,
+  deleteItem,
+  startEditing,
+  setItems,
+}: UseCommandsParams) {
+  const handleCommand = (cmd: string) => {
+    const parts = cmd.split(/\s+/);
+    const command = parts[0].toLowerCase();
+
+    if (command === "/del" && parts[1]) {
+      const num = parseInt(parts[1], 10);
+      if (!isNaN(num) && num >= 1) {
+        // 번호는 1부터 시작, 배열 인덱스는 0부터
+        deleteItem(num - 1);
+      }
+    } else if (command === "/pop") {
+      // 맨 위(첫 번째) 아이템 삭제
+      deleteItem(0);
+    } else if (command === "/edit" && parts[1]) {
+      const num = parseInt(parts[1], 10);
+      if (!isNaN(num) && num >= 1 && num <= items.length) {
+        startEditing(items[num - 1].id);
+      }
+    } else if (command === "/clear") {
+      // 모든 아이템 삭제
+      setItems([]);
+    }
+  };
+
+  return { handleCommand };
+}

--- a/src/hooks/useStore.ts
+++ b/src/hooks/useStore.ts
@@ -1,0 +1,48 @@
+import { useState, useRef, useEffect } from "react";
+import { LazyStore } from "@tauri-apps/plugin-store";
+import type { StackItem } from "../types";
+
+const store = new LazyStore("store.json");
+
+export function useStore() {
+  const [items, setItems] = useState<StackItem[]>([]);
+  const nextIdRef = useRef(1);
+  const isLoadedRef = useRef(false);
+
+  // 앱 시작 시 저장된 데이터 로드
+  useEffect(() => {
+    (async () => {
+      try {
+        const savedItems = await store.get<StackItem[]>("items");
+        const savedNextId = await store.get<number>("nextId");
+        if (savedItems) setItems(savedItems);
+        if (savedNextId) nextIdRef.current = savedNextId;
+      } catch (e) {
+        console.error("데이터 로드 실패:", e);
+      } finally {
+        isLoadedRef.current = true;
+      }
+    })();
+  }, []);
+
+  // items 변경 시 자동 저장
+  useEffect(() => {
+    if (!isLoadedRef.current) return;
+
+    (async () => {
+      try {
+        await store.set("items", items);
+        await store.set("nextId", nextIdRef.current);
+      } catch (e) {
+        console.error("데이터 저장 실패:", e);
+      }
+    })();
+  }, [items]);
+
+  // 새 아이템을 맨 위에 추가
+  const addItem = (text: string) => {
+    setItems((prev) => [{ id: nextIdRef.current++, text }, ...prev]);
+  };
+
+  return { items, setItems, addItem };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export interface StackItem {
+  id: number;
+  text: string;
+}


### PR DESCRIPTION
## Summary
- **CSP 설정 (#18)**: `tauri.conf.json`의 `csp`를 `null`에서 `"default-src 'self'; style-src 'self' 'unsafe-inline'"`로 변경 (`@dnd-kit` inline 스타일 허용)
- **App.tsx 분리 (#19)**: 351줄 단일 파일을 타입, 훅, 컴포넌트로 분리하여 212줄로 축소

### 신규 파일
| 파일 | 역할 |
|------|------|
| `src/types.ts` | `StackItem` 공유 타입 |
| `src/hooks/useStore.ts` | LazyStore 래핑 (로드/저장/addItem) |
| `src/hooks/useCommands.ts` | 슬래시 명령어 파싱 |
| `src/components/InputBar.tsx` | 입력창 + 핀 버튼 |
| `src/components/StackItem.tsx` | 드래그 가능한 개별 아이템 |
| `src/components/EmptyState.tsx` | 빈 상태 안내 텍스트 |

Closes #18, Closes #19

## Test plan
- [ ] `npx tsc --noEmit` 타입 에러 없음 ✅
- [ ] `npm run lint` 린트 통과 ✅
- [ ] 아이템 추가/삭제 동작 확인
- [ ] 슬래시 명령어 (/del, /pop, /edit, /clear) 동작 확인
- [ ] 더블클릭 편집 동작 확인
- [ ] 드래그 앤 드롭 순서 변경 확인
- [ ] 핀 토글 (Ctrl+Shift+P) 동작 확인
- [ ] CSP 콘솔 에러 없이 실행 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)