### PR TITLE
feat: 아이템 age 표시 (생성 경과 시간)

### DIFF
--- a/src/components/StackItem.tsx
+++ b/src/components/StackItem.tsx
@@ -1,6 +1,8 @@
+import { useState, useEffect } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { StackItem as StackItemType } from "../types";
+import { formatAge } from "../utils/timeAge";
 
 interface StackItemProps {
   item: StackItemType;
@@ -26,6 +28,13 @@ export function SortableItem({
   handleEditKeyDown,
   deleteItem,
 }: StackItemProps) {
+  const [age, setAge] = useState(() => formatAge(item.createdAt));
+
+  useEffect(() => {
+    const timer = setInterval(() => setAge(formatAge(item.createdAt)), 60_000);
+    return () => clearInterval(timer);
+  }, [item.createdAt]);
+
   const isEditing = editingId === item.id;
   const {
     attributes,
@@ -65,6 +74,7 @@ export function SortableItem({
       ) : (
         <span className="content">{item.text}</span>
       )}
+      <span className="age">{age}</span>
       <button
         className="delete-btn"
         onClick={() => deleteItem(index)}

--- a/src/hooks/useStore.ts
+++ b/src/hooks/useStore.ts
@@ -15,7 +15,14 @@ export function useStore() {
       try {
         const savedItems = await store.get<StackItem[]>("items");
         const savedNextId = await store.get<number>("nextId");
-        if (savedItems) setItems(savedItems);
+        if (savedItems) {
+          const now = Date.now();
+          const migrated = savedItems.map((item) => ({
+            ...item,
+            createdAt: item.createdAt ?? now,
+          }));
+          setItems(migrated);
+        }
         if (savedNextId) nextIdRef.current = savedNextId;
       } catch (e) {
         console.error("데이터 로드 실패:", e);
@@ -41,7 +48,7 @@ export function useStore() {
 
   // 새 아이템을 맨 위에 추가
   const addItem = (text: string) => {
-    setItems((prev) => [{ id: nextIdRef.current++, text }, ...prev]);
+    setItems((prev) => [{ id: nextIdRef.current++, text, createdAt: Date.now() }, ...prev]);
   };
 
   return { items, setItems, addItem };

--- a/src/styles.css
+++ b/src/styles.css
@@ -181,6 +181,13 @@ body {
   border-color: var(--accent);
 }
 
+.stack-item .age {
+  color: var(--text-muted);
+  font-size: 11px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 .stack-item .delete-btn {
   background: none;
   border: none;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export interface StackItem {
   id: number;
   text: string;
+  createdAt: number; // Date.now() 타임스탬프
 }

--- a/src/utils/timeAge.ts
+++ b/src/utils/timeAge.ts
@@ -1,0 +1,9 @@
+// 경과 시간 포맷 유틸
+export function formatAge(createdAt: number): string {
+  const diff = Math.floor((Date.now() - createdAt) / 1000);
+  if (diff < 60) return "방금";
+  if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
+  if (diff < 2592000) return `${Math.floor(diff / 86400)}일 전`;
+  return `${Math.floor(diff / 2592000)}개월 전`;
+}


### PR DESCRIPTION
## Summary
- Closes #17
- `StackItem`에 `createdAt` 타임스탬프 필드 추가
- 기존 저장 데이터 마이그레이션 (createdAt 없으면 현재 시간 할당)
- 경과 시간 포맷 유틸 추가 (방금 / N분 전 / N시간 전 / N일 전 / N개월 전)
- 삭제 버튼 왼쪽에 muted 스타일로 age 표시, 1분 주기 자동 갱신

## Test plan
- [x] `npm run dev`로 프론트엔드 실행 후 브라우저에서 확인
- [x] 새 아이템 추가 시 "방금" 표시 확인
- [x] 1분 경과 후 "1분 전" 전환 확인
- [ ] 기존 저장 아이템 로드 시 마이그레이션 동작 확인
- [ ] `npx tsc --noEmit` 타입 체크 통과 ✅
- [ ] `npm run lint` 린트 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)